### PR TITLE
Updates 'bikes' statement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ These spaces contain shared resources, e.g. the microwave and refrigerator, but 
 - The kitchen and fridge will be cleaned thoroughly once a month. Volunteers will be incentivized.  
 
 ### Space issues
-- Bikes are not permitted in MIT Buildings - please lock outside.
+- If you choose to bring your bike into Cubespace, please store it in your cubicle.
 
 ### Scents
 - Be mindful of your neighbors regarding personal hygiene and odors such as perfume, cologne, flowers, smelly foods, etc. 


### PR DESCRIPTION
This was also the subject of much discussion and consultation with the Libraries and MIT Police. The statement dates back to a proposed renovation of Cubespace that would have shrunk individual cubes, and a recognition that Cubespace is increasingly filled with people. However, many people objected to the statement corrected by this PR - so the norms group investigated.

In the end, we found that the statement about bikes not being allowed in MIT buildings is not factually correct. The statement from the MIT Police we received was:

```
Good Afternoon,

To my knowledge there are no rules against walking bikes indoors. Some people choose to bring their
bikes into their offices. As long as the bike is not impeding foot traffic or violating a
department or office policy, there should be no issue from our perspective. Keep in mind, if it's
not locked down and has some value, it can walk (or roll) away quickly, whatever it is. I hope this
helps.


ANDREW J. TURCO
Crime Prevention Sergeant
MIT Police Department
```

Based on all of these inputs, the norms group put together this amended statement, which we believe to better capture the perspectives voiced by everyone.