### PR TITLE
Updates norm about scheduling meeting spaces

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ These spaces contain shared resources, e.g. the microwave and refrigerator, but 
 - Be mindful of your neighbors regarding personal hygiene and odors such as perfume, cologne, flowers, smelly foods, etc. 
 
 ## Meeting
-Shared conference rooms are available for scheduled, and when possible, longer unscheduled conversations. When meeting in any of these spaces, please close the door. Both come equipped with a telephone and video conferencing capabilities.
+Shared conference rooms are available for scheduled, and when possible, longer unscheduled conversations. When meeting in _any_ of these spaces, book the room via its Outlook calendar, and please close the door. Both come equipped with a telephone and video conferencing capabilities.
 
 **Smaller conference room:** ("LIB: E25-131 Cubespace Sm Mtg Rm" in Outlook)
 - 1-3 people


### PR DESCRIPTION
After a question about the recommended practice around impromptu use of meeting spaces, the group decided to clarify that _all_ use should be indicated on Outlook. This will prevent conflicts where multiple groups see an apparently unused space on the calendar and attempt to use it informally - particularly for people coming from outside Cubespace.

Eventually this impromptu use will be better facilitated by panels at the doors to enable immediate scheduling - but those have not yet been set up. Documentation of this will be added to this document when it occurs.